### PR TITLE
Fix game server crash when snake body size underflow

### DIFF
--- a/game.py
+++ b/game.py
@@ -40,6 +40,7 @@ class Snake:
 
     def grow(self, amount=1):
         self.to_grow += amount
+        self.to_grow = max(- len(self._body) + 1, self.to_grow)
 
     @property
     def head(self):


### PR DESCRIPTION
There is sometimes a game server crash when a snake eats a SuperFood, caused by the following exception:
```
Traceback (most recent call last):
  (...)
  File "../ia-snakes/game.py", line 46, in head
    return self._body[-1]
           ~~~~~~~~~~^^^^
IndexError: list index out of range
```
The reason behind this is in one of the effects of SuperFood, reducing the size of the snake by up to 2 units. If the reduction is equal to or greater than its size, the `self.to_grow` list will be empty, causing an `out-of-range list index` when we call `head`.

The proposed solution creates a minimum limit, ensuring that the size reduction is smaller than the size of the snake itself.
