### PR TITLE
Fixed client/OS forced disconnection making server crash

### DIFF
--- a/server.py
+++ b/server.py
@@ -95,7 +95,7 @@ class GameServer:
                 await client.send(json.dumps(info))
             except Exception:
                 to_remove.append(client)
-                client.close()
+                await client.close()
         for client in to_remove:
             if isinstance(original_group, dict):
                 del original_group[client]        


### PR DESCRIPTION
The server could crash if the client connection was terminated by an external factor (ex: keepalive ping response never arrives to the server).

Added a missing await to make the server not crash.

