### PR TITLE
Possibly fixed a weird RuntimeError: Set changed size during iteration

### DIFF
--- a/server.py
+++ b/server.py
@@ -90,7 +90,7 @@ class GameServer:
         if isinstance(group, dict):
             group = group.keys()
 
-        for client in group:
+        for client in list(group):
             try:
                 await client.send(json.dumps(info))
             except Exception:


### PR DESCRIPTION
A very weird set changed size exception occurs when a client disconnects via OS interference
```
2024-11-05 14:35:36,179 - Server - INFO - Client disconnected: sent 1011 (internal error) keepalive ping timeout; no close frame received
2024-11-05 14:35:36,180 - urllib3.connectionpool - DEBUG - Starting new HTTP connection (1): tetriscores.av.it.pt:80
2024-11-05 14:35:36,227 - urllib3.connectionpool - DEBUG - http://tetriscores.av.it.pt:80 "POST /game HTTP/1.1" 200 99
2024-11-05 14:35:36,228 - Server - INFO - Disconnecting <PRamos>
Traceback (most recent call last):
...
  File "/home/frostywolf/Documents/GitReps/MRSI/SI-I/TPG_snake/server.py", line 251, in main
    await asyncio.gather(websocket_server, game_loop_task)
  File "/home/frostywolf/Documents/GitReps/MRSI/SI-I/TPG_snake/server.py", line 170, in mainloop
    await self.send_clients(self.viewers, state)
  File "/home/frostywolf/Documents/GitReps/MRSI/SI-I/TPG_snake/server.py", line 93, in send_clients
    for client in group:
                  ^^^^^
RuntimeError: Set changed size during iteration

```

This happens despite the code itself not actually manipulating the set, so maybe copying it to a seperate list will stop this from happening.

I'm not exactly sure, but I'm guessing the .close() function is somehow altering the client class or data (no response to the close handshake is returned) and if two clients disconnect they will "merge" in the set and cause the size to change.
